### PR TITLE
Add conditional compilation support for external float formatting and parsing

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -81,7 +81,7 @@ def construct():
     else:
         config_builder = pkgconfig_builder
         config_parser = pkgconfig_parser(prefix)
-
+    float_formatter = ARGUMENTS.get('float_formatter', False)
     for target_arch in target_architectures():
         target_ccflags = TARGET_FLAGS[target_arch] + ccflags
         target_cppdefines = TARGET_DEFINES[target_arch]
@@ -105,6 +105,8 @@ def construct():
                 env['CC'] = cc_override
             if ranlib_override:
                 env['RANLIB'] = ranlib_override
+            if float_formatter:
+                env['FLOAT_FORMATTER'] = float_formatter
             if target_arch == "darwin":
                 env.AppendENVPath("PATH", "/opt/local/bin")
             SConscript(dirs=directory,

--- a/src/SConscript
+++ b/src/SConscript
@@ -9,10 +9,15 @@ env['CCFLAGS'] += ' -fPIC'
 
 env['CPPPATH'] = [
     '#include',
+    '.'
 ]
 
 env.ParseConfig(env['CONFIG_PARSER'])
 
+env.InstallAs('encjson_float_formatter.c',
+              env.get('FLOAT_FORMATTER', 'default_float_formatter.c'))
+
 env.StaticLibrary('encjson',
                   [ 'encjson.c',
+                    'encjson_float_formatter.c',
                     'encjson_version.c' ])

--- a/src/default_float_formatter.c
+++ b/src/default_float_formatter.c
@@ -1,0 +1,18 @@
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "encjson_int.h"
+
+void encjson_internal_encode_float(double value, char buffer[])
+{
+    /* Note: this is sensitive to setlocale() in the application. */
+    sprintf(buffer, "%.21g", value);
+}
+
+bool encjson_internal_decode_float(const char buffer[], double *value)
+{
+    /* Note: this is sensitive to setlocale() in the application. */
+    *value = strtod(buffer, NULL);
+    return *value == 0 || errno != ERANGE;
+}

--- a/src/encjson.c
+++ b/src/encjson.c
@@ -1086,14 +1086,15 @@ static const char *decode_object(const char *p, const char *end,
 
 static const char *scan_hex_digit(const char *p, const char *end, int *digit)
 {
-    if (!p || exhausted(p, end))
+    if (!p || exhausted(p, end)) {
+        *digit = -1; /* don't-care to avoid compiler warnings */
         return NULL;
-    unsigned value = charstr_digit_value(*p);
-    if (value == -1U) {
+    }
+    *digit = charstr_digit_value(*p);
+    if (*digit == -1) {
         json_error();
         return NULL;
     }
-    *digit = value;
     return skip(p, end, *p);
 }
 

--- a/src/encjson_int.h
+++ b/src/encjson_int.h
@@ -1,0 +1,11 @@
+#include <stdbool.h>
+
+/* Serialize the given value, which isnormal(3), into buffer, which
+ * can be assumed to be sufficiently large to hold the entire
+ * encoding. Terminate the encoding with NUL.  */
+extern void encjson_internal_encode_float(double value, char buffer[]);
+
+/* Deserialize the NUL-terminated buffer into value. Ignore possible
+ * trailing bytes. Return false if the input is invalid. It is ok to
+ * pass a value that !isnormal(3). */
+extern bool encjson_internal_decode_float(const char buffer[], double *value);

--- a/test/test_decode_empty_file.c
+++ b/test/test_decode_empty_file.c
@@ -1,5 +1,6 @@
 #include <errno.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 #include <encjson.h>
 
@@ -8,5 +9,8 @@ int main()
     FILE *f = tmpfile();
     json_thing_t *thing = json_utf8_decode_file(f, (size_t) -1);
     fclose(f);
-    return thing || errno != EINVAL;
+    if (thing || errno != EINVAL)
+        return EXIT_FAILURE;
+    fprintf(stderr, "Ok\n");
+    return EXIT_SUCCESS;
 }

--- a/test/test_decode_file.c
+++ b/test/test_decode_file.c
@@ -1,7 +1,9 @@
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include <encjson.h>
+#include <fsdyn/charstr.h>
 
 int main()
 {
@@ -10,20 +12,27 @@ int main()
     char buffer[size];
     (void) json_utf8_encode(thing, buffer, size);
     printf("%s\n", buffer);
-    const char *expected = "{"
-                           "\"string\":\"\\t\\\"¿xyzzy? 𤭢\","
-                           "\"truth\":true,"
-                           "\"lie\":false,"
-                           "\"nothing\":null,"
-                           "\"year\":2017,"
-                           "\"months\":[1,3,5,7,8,10,12],"
-                           "\"π\":3.14159265000000020862"
-                           "}";
-    if (strcmp(buffer, expected)) {
-        fprintf(stderr, "Error: expected\n%s\n", expected);
-        return 1;
+    const char *expected_prefix = "{"
+                                  "\"string\":\"\\t\\\"¿xyzzy? 𤭢\","
+                                  "\"truth\":true,"
+                                  "\"lie\":false,"
+                                  "\"nothing\":null,"
+                                  "\"year\":2017,"
+                                  "\"months\":[1,3,5,7,8,10,12],"
+                                  "\"π\":";
+    double expected_middle = 31415.9265e-4;
+    const char *expected_suffix = "}";
+    const char *then = charstr_skip_prefix(buffer, expected_prefix);
+    const char *finally = "";
+    double value = 0;
+    if (then)
+        value = strtod(then, (char **) &finally);
+    if (!then || value != expected_middle || finally == then) {
+        fprintf(stderr, "Error: expected\n%s%g%s\n", expected_prefix,
+                expected_middle, expected_suffix);
+        return EXIT_FAILURE;
     }
     json_destroy_thing(thing);
     fprintf(stderr, "Ok\n");
-    return 0;
+    return EXIT_SUCCESS;
 }


### PR DESCRIPTION
The default behavior is unchanged. However, one can implement the API specified in encjson_int.h with an external C source file and pass it to SCons with the float_formatter build variable.

Motivation:
- The standard library functions strtod(3) and sprintf(3) are sensitive to the application's locale and will break should the decimal separator change.
- Glibc's sprintf(3) produces aesthetically unpleasant extra digits when formatting numbers like 0.07.

Both objectives can be solved with some non-stdlib code.